### PR TITLE
Drop outdated dependecies. Switch to github actions.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,48 @@
+name: run-tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [7.4, 7.3]
+        laravel: [8.*, 7.*, 6.*]
+        dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 8.*
+            testbench: 6.*
+          - laravel: 7.*
+            testbench: 5.*
+          - laravel: 6.*
+            testbench: 4.*
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,13 +1,16 @@
-name: run-tests
+name: Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   test:
-
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
     runs-on: ubuntu-latest
+
     strategy:
-      fail-fast: false
       matrix:
         php: [7.4, 7.3]
         laravel: [8.*, 7.*, 6.*]
@@ -20,19 +23,17 @@ jobs:
           - laravel: 6.*
             testbench: 4.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
-
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v2
 
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          key: php-${{ matrix.php }}-laravel-${{ matrix.laravel }}-composer-${{ hashFiles('composer.lock') }}
 
-      - name: Setup PHP
+      - name: Set up PHP
         uses: shivammathur/setup-php@v1
         with:
           php-version: ${{ matrix.php }}
@@ -44,5 +45,5 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
-      - name: Execute tests
-        run: vendor/bin/phpunit
+      - name: Run tests
+        run: vendor/bin/phpunit --testdox --colors=always

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
         }
     ],
     "require": {
-        "php": "^7.3",
-        "illuminate/config": "~6.0|~7.0|~8.0",
-        "illuminate/console": "~6.0|~7.0|~8.0",
-        "illuminate/log": "~6.0|~7.0|~8.0",
-        "illuminate/support": "~6.0|~7.0|~8.0"
+        "php": "^7.1.3",
+        "illuminate/config": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0",
+        "illuminate/console": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0",
+        "illuminate/log": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0",
+        "illuminate/support": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.8",
         "laravel/legacy-factories": "^1.0.4",
         "mockery/mockery": "^1.0.0",
-        "orchestra/testbench": "~4.0|~5.0|~6.0",
+        "orchestra/testbench": "~3.0|~4.0|~5.0|~6.0",
         "phpunit/phpunit": "~8.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
-        "illuminate/config": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0",
-        "illuminate/console": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0",
-        "illuminate/log": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0",
-        "illuminate/support": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0"
+        "php": "^7.3",
+        "illuminate/config": "~6.0|~7.0|~8.0",
+        "illuminate/console": "~6.0|~7.0|~8.0",
+        "illuminate/log": "~6.0|~7.0|~8.0",
+        "illuminate/support": "~6.0|~7.0|~8.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.8",
-        "laravel/legacy-factories": "^1.0",
+        "laravel/legacy-factories": "^1.0.4",
         "mockery/mockery": "^1.0.0",
-        "orchestra/testbench": "~3.0|~4.0|~5.0|~6.0",
+        "orchestra/testbench": "~4.0|~5.0|~6.0",
         "phpunit/phpunit": "~8.0"
     },
     "autoload": {


### PR DESCRIPTION
Currently this project uses Codeship, it seems, to check the build status of the project. This requires a signin to see why a PR might be failing. 
This PR adds github actions which allows people to see the status of a PR and what might be causing it to fail (eg old dependencies, etc).

This PR drops Laravel 5 support, as Laravel no longer supports Laravel 5.
This PR drops PHP 7.1.3 support and PHP 7.2 support because both Laravel 8 and PHPUnit require 7.3+. 
This bumps laravel/legacy-factories from 1.0 to 1.0.4, since there was a problem before 1.0.4 with the Macroable class, which broke certain testing builds.